### PR TITLE
Throw authentication exception if auth request failed

### DIFF
--- a/smartTV.php
+++ b/smartTV.php
@@ -119,13 +119,20 @@ class SmartTV {
 		if ($this->pairingKey === null) {
 			throw new Exception('No pairing key given.');
 		}
-		return ($this->session = $this->sendXMLRequest('/roap/api/auth', self::encodeData(
+
+		$this->session = $this->sendXMLRequest('/roap/api/auth', self::encodeData(
 			array(
 				'type' => 'AuthReq',
 				'value' => $this->pairingKey
 			),
 			'auth'
-		))['session']);
+		));
+
+		if (!$this->session) {
+			throw new Exception('Authentication request failed.');
+		}
+
+		return $this->sesssion['session'];
 	}
 
 	public function processCommand($commandName, $parameters = []) {


### PR DESCRIPTION
If wrong host or port is specified application throws the following notice and error:

```
PHP Notice:  Trying to access array offset on value of type bool in /home/jakub/programowanie/PHP-LG-SmartTV/smartTV.php on line 128
PHP Fatal error:  Uncaught Exception: No session id given. in /home/jakub/programowanie/PHP-LG-SmartTV/smartTV.php:133
```

My change checks the return value of method sendXMLRequest and throws exception if needed.